### PR TITLE
Fix Installation from Wordpress Marketplace

### DIFF
--- a/give-duitku.php
+++ b/give-duitku.php
@@ -83,7 +83,9 @@ if (!class_exists('Give_Duitku')):
     protected function __construct() {
       add_action('admin_init', array($this, 'check_environment'));
       add_action('plugins_loaded', array($this, 'init'));
-      $this->includes();
+      add_action('before_give_init', function () {
+        $this->includes();
+      });
     }
 
     /**


### PR DESCRIPTION
Issue : Can Install plugin Duitku GiveWP from Wordpress Marketplace, but the plugin settings did not show

RC : if using any name folder, 

> WordPress loads plugins alphabetically by folder name. 

the plugin was processed before the GiveWP was fully initialized, but if using the specific name folder it became normally installed

Fix : add code to wait until GiveWP start


